### PR TITLE
Fix unintended printf-style formatting

### DIFF
--- a/Api/ImGuiExport.cs
+++ b/Api/ImGuiExport.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.MappingUtils.Api;
 public static class ImGuiExport
 {
     [MinMappingUtilsVersion("1.10.1")]
-    public static void Text(string txt) => ImGui.Text(txt);
+    public static void Text(string txt) => ImGui.TextUnformatted(txt);
     
     [MinMappingUtilsVersion("1.10.1")]
     public static bool Button(string label) => ImGui.Button(label);

--- a/ImGuiExt.cs
+++ b/ImGuiExt.cs
@@ -24,7 +24,7 @@ public static class ImGuiExt
         if (tooltip is { } && ImGui.IsItemHovered())
         {
             ImGui.BeginTooltip();
-            ImGui.Text(tooltip);
+            ImGui.TextUnformatted(tooltip);
             ImGui.EndTooltip();
         }
 
@@ -60,7 +60,7 @@ public static class ImGuiExt
         if (tooltip is { } && ImGui.IsItemHovered())
         {
             ImGui.BeginTooltip();
-            ImGui.Text(tooltip);
+            ImGui.TextUnformatted(tooltip);
             ImGui.EndTooltip();
         }
     }
@@ -80,9 +80,35 @@ public static class ImGuiExt
         if (ImGui.IsItemHovered())
         {
             ImGui.BeginTooltip();
-            ImGui.TextColored(Color.LightGray.ToNumVec4(), $"Added by mod '{modName}'");
+            TextColoredUnformatted(Color.LightGray.ToNumVec4(), $"Added by mod '{modName}'");
             ImGui.EndTooltip();
         }
+    }
+
+    // NOTE:
+    // ImGui's text widgets accept printf-style formatting except for TextUnformatted.
+    // be careful when passing arbitrary text that could contain a percent sign (%),
+    // as it will be interpreted as a format specifier and perform out-of-bounds accesses.
+    // the following text methods are affected:
+    // - ImGui.Text()
+    // - ImGui.TextColored()
+    // - ImGui.TextDisabled()
+    // - ImGui.TextWrapped()
+    // - ImGui.LabelText() (second argument)
+    // - ImGui.BulletText()
+
+    public static void TextColoredUnformatted(NumVector4 color, string text)
+    {
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextUnformatted(text);
+        ImGui.PopStyleColor();
+    }
+
+    public static void TextColoredUnformatted(NumVector4 color, ReadOnlySpan<char> text)
+    {
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextUnformatted(text);
+        ImGui.PopStyleColor();
     }
 
     public static bool ColorEdit(string label, ref Color color, ColorFormat format, string? tooltip = null)
@@ -130,7 +156,7 @@ public static class ImGuiExt
 
 
         ImGui.SameLine(0f, xPadding);
-        ImGui.Text(label);
+        ImGui.TextUnformatted(label);
         true.WithTooltip(tooltip);
 
         return edited;

--- a/ImGuiHandlers/IlDiffView.cs
+++ b/ImGuiHandlers/IlDiffView.cs
@@ -52,7 +52,7 @@ internal sealed class IlDiffView(MethodDiff diff) : ImGuiHandler
                 _ => throw new ArgumentOutOfRangeException()
             }).ToNumVec4();
                 
-            ImGui.TextColored(color, instr.Type switch
+            ImGuiExt.TextColoredUnformatted(color, instr.Type switch
             {
                 MethodDiff.ElementType.Unchanged => "",
                 MethodDiff.ElementType.Added => "+",
@@ -61,7 +61,7 @@ internal sealed class IlDiffView(MethodDiff diff) : ImGuiHandler
             });
                 
             ImGui.TableNextColumn();
-            ImGui.TextColored(color, instr.Instruction.FixedToString());
+            ImGuiExt.TextColoredUnformatted(color, instr.Instruction.FixedToString());
                 
             ImGui.TableNextColumn();
 
@@ -79,7 +79,7 @@ internal sealed class IlDiffView(MethodDiff diff) : ImGuiHandler
 
                     ImGui.TableNextColumn();
                     
-                    ImGui.TextColored(Color.Orange.ToNumVec4(), additional);
+                    ImGuiExt.TextColoredUnformatted(Color.Orange.ToNumVec4(), additional);
                 }
             }
         }

--- a/ImGuiHandlers/Tabs/CountersTab.cs
+++ b/ImGuiHandlers/Tabs/CountersTab.cs
@@ -29,9 +29,9 @@ internal class CountersTab : Tab
         foreach (var c in counters)
         {
             ImGui.TableNextColumn();
-            ImGui.Text("Counter");
+            ImGui.TextUnformatted("Counter");
             ImGui.TableNextColumn();
-            ImGui.Text(c.Key);
+            ImGui.TextUnformatted(c.Key);
             ImGui.TableNextColumn();
             ImGui.SetNextItemWidth(ImGui.GetColumnWidth());
             ImGui.InputInt($"##c_{c.Key}", ref c.Value, 1, 1);
@@ -41,9 +41,9 @@ internal class CountersTab : Tab
         foreach (var (name, slider) in sliders)
         {
             ImGui.TableNextColumn();
-            ImGui.Text("Slider");
+            ImGui.TextUnformatted("Slider");
             ImGui.TableNextColumn();
-            ImGui.Text(name);
+            ImGui.TextUnformatted(name);
             ImGui.TableNextColumn();
             ImGui.SetNextItemWidth(ImGui.GetColumnWidth());
             var value = slider.Value;

--- a/ImGuiHandlers/Tabs/EntitiesTab.cs
+++ b/ImGuiHandlers/Tabs/EntitiesTab.cs
@@ -48,7 +48,7 @@ public class EntitiesTab : Tab
                 _selectedEntity = null;
             }
             ImGui.SameLine();
-            ImGui.Text(displayName);
+            ImGui.TextUnformatted(displayName);
             
             if (open)
             {
@@ -108,7 +108,7 @@ public class EntitiesTab : Tab
             }
             
             ImGui.TableNextColumn();
-            ImGui.Text(group.Count().ToString());
+            ImGui.TextUnformatted(group.Count().ToString());
         }
         
         ImGui.EndTable();

--- a/ImGuiHandlers/Tabs/GcTab.cs
+++ b/ImGuiHandlers/Tabs/GcTab.cs
@@ -139,11 +139,11 @@ internal sealed class GcTab : Tab
         /*
         _pausesForPlot.CopyTo(_pausesForPlotSorted, 0);
         _pausesForPlotSorted.AsSpan().Sort();
-        ImGui.Text($"P99.9 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.999)).SafeMax(0)}ms");
-        ImGui.Text($"P99 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.99)).SafeMax(0)}ms");
-        ImGui.Text($"P95 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.95)).SafeMax(0)}ms");
-        ImGui.Text($"P90 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.9)).SafeMax(0)}ms");
-        ImGui.Text($"P80 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.8)).SafeMax(0)}ms");
+        ImGui.TextUnformatted($"P99.9 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.999)).SafeMax(0)}ms");
+        ImGui.TextUnformatted($"P99 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.99)).SafeMax(0)}ms");
+        ImGui.TextUnformatted($"P95 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.95)).SafeMax(0)}ms");
+        ImGui.TextUnformatted($"P90 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.9)).SafeMax(0)}ms");
+        ImGui.TextUnformatted($"P80 GC Pause: {_pausesForPlotSorted.Take((int)(pauseAmt * 0.8)).SafeMax(0)}ms");
         */
         ImGui.PlotHistogram("GC Times:", ref _pausesForPlot[0], _pausesForPlot.Length, 0, "GC Pause Times", 0f, 32f, ImGui.GetContentRegionAvail());
     }

--- a/ImGuiHandlers/Tabs/HooksTab.cs
+++ b/ImGuiHandlers/Tabs/HooksTab.cs
@@ -36,7 +36,7 @@ internal sealed class HooksTab : Tab
 
         if (_detourInfo is { })
         {
-            ImGui.Text(_selectedMethod.GetMethodNameForDB());
+            ImGui.TextUnformatted(_selectedMethod.GetMethodNameForDB());
 
             ImGui.Button("Decompile");
             ImGuiExt.AddDecompilationTooltip(_selectedMethod);
@@ -60,26 +60,26 @@ internal sealed class HooksTab : Tab
                     {
                         case ILHookInfo ilHook:
                         {
-                            ImGui.Text(ilHook.ManipulatorMethod.Name);
+                            ImGui.TextUnformatted(ilHook.ManipulatorMethod.Name);
                             ImGui.TableNextColumn();
 
-                            ImGui.Text("IL");
+                            ImGui.TextUnformatted("IL");
                             ImGui.TableNextColumn();
 
-                            ImGui.Text(ilHook.ManipulatorMethod.GetMethodNameForDB());
+                            ImGui.TextUnformatted(ilHook.ManipulatorMethod.GetMethodNameForDB());
                             ImGuiExt.AddDecompilationTooltip(ilHook.ManipulatorMethod);
                             ImGui.TableNextColumn();
                             break;
                         }
                         case DetourInfo hook:
                         {
-                            ImGui.Text(hook.Entry.Name);
+                            ImGui.TextUnformatted(hook.Entry.Name);
                             ImGui.TableNextColumn();
                             
-                            ImGui.Text("On");
+                            ImGui.TextUnformatted("On");
                             ImGui.TableNextColumn();
 
-                            ImGui.Text(hook.Entry.GetMethodNameForDB());
+                            ImGui.TextUnformatted(hook.Entry.GetMethodNameForDB());
                             ImGuiExt.AddDecompilationTooltip(hook.Entry);
                             ImGui.TableNextColumn();
                             break;

--- a/ImGuiHandlers/Tabs/LogTab.cs
+++ b/ImGuiHandlers/Tabs/LogTab.cs
@@ -21,7 +21,7 @@ public class LogTab : Tab
     {
         if (Everest.PathLog is not { })
         {
-            ImGui.Text("The Everest log is disabled.");
+            ImGui.TextUnformatted("The Everest log is disabled.");
             return;
         }
         
@@ -113,12 +113,14 @@ public class LogTab : Tab
         private static readonly Regex LogLineRegex = new(@"^\(.+?\) \[(.+?)\] \[(.+?)\] \[(.+?)\]", RegexOptions.Compiled);
         
         public LogLevel LogLevel { get; }
-        
+
         public string Line { get; }
 
         public LogEntry(string line)
         {
-            Line = line;
+            // this will be passed to ImGui.TextWrapped which accepts printf-style formatting;
+            // we need to escape percent signs to prevent accidental format specifiers
+            Line = line.Replace("%", "%%");
 
             if (LogLineRegex.Match(line) is { Success: true } match)
             {

--- a/ImGuiHandlers/Tabs/ParticleTab.cs
+++ b/ImGuiHandlers/Tabs/ParticleTab.cs
@@ -258,7 +258,7 @@ internal static class ParticleExporterRegistry
     {
         if (ImGui.Button($"{name} [{modName}]").WithTooltip(tooltip).WithTooltip(() =>
             {
-                ImGui.TextColored(Color.LightGray.ToNumVec4(), $"Requires mod '{modName}'");
+                ImGuiExt.TextColoredUnformatted(Color.LightGray.ToNumVec4(), $"Requires mod '{modName}'");
             }))
         {
             var text = exportFunc(particle);
@@ -283,7 +283,7 @@ internal static class ParticleExporterRegistry
         
         if (ImGui.Button($"{name} [{modName}]").WithTooltip(tooltip).WithTooltip(() =>
             {
-                ImGui.TextColored(Color.LightGray.ToNumVec4(), $"Requires mod '{modName}'");
+                ImGuiExt.TextColoredUnformatted(Color.LightGray.ToNumVec4(), $"Requires mod '{modName}'");
             }))
         {
             var text = exportFunc(particle, emitter);

--- a/ImGuiHandlers/Tabs/ProfilingTab.cs
+++ b/ImGuiHandlers/Tabs/ProfilingTab.cs
@@ -403,7 +403,7 @@ internal class ProfilingTab : Tab
                 (string str) => MappingUtilsModule.Settings.ProfilerHookedMethods.FirstOrDefault(m => m.Name == str)?.FindMethod()?.DeclaringType
             );
             
-            ImGui.Text(GetName(name));
+            ImGui.TextUnformatted(GetName(name));
             if (declaringType is { })
             {
                 ImGuiExt.AddDecompilationTooltip(declaringType, null);
@@ -446,7 +446,7 @@ internal class ProfilingTab : Tab
                 var color = Color.Lerp(Color.White, Color.Red, (float)p * colorMult);
 
                 ImGui.TableNextColumn();
-                ImGui.TextColored(color.ToNumVec4(), Interpolator.Temp($"{(p*100):F1}%%"));
+                ImGuiExt.TextColoredUnformatted(color.ToNumVec4(), Interpolator.Temp($"{(p*100):F1}%%"));
             }
 
             static void RenderTime(TimeSpan time, TimeSpan totalTime)
@@ -458,7 +458,7 @@ internal class ProfilingTab : Tab
                     return;
                 
                 var color = Color.Lerp(Color.White, Color.Red, (float)(time / totalTime) * 20f);
-                ImGui.TextColored(color.ToNumVec4(), Interpolator.Temp($"{timeMs:F3}"));
+                ImGuiExt.TextColoredUnformatted(color.ToNumVec4(), Interpolator.Temp($"{timeMs:F3}"));
             }
         }
 

--- a/ImGuiHandlers/Tabs/StylegroundViewTab.cs
+++ b/ImGuiHandlers/Tabs/StylegroundViewTab.cs
@@ -31,7 +31,7 @@ public class StylegroundViewTab : Tab
 
         if (Selection is { } s)
         {
-            ImGui.Text($"Edit style - {GetName(s)}");
+            ImGui.TextUnformatted($"Edit style - {GetName(s)}");
 
             ImGui.SetNextItemWidth(ItemWidth);
             ImGuiExt.ColorEdit("Color", ref s.Color, Helpers.ColorFormat.RGBA, null);
@@ -217,7 +217,7 @@ public class StylegroundViewTab : Tab
             ImGui.BeginDisabled();
         }
 
-        ImGui.Text(GetName(style));
+        ImGui.TextUnformatted(GetName(style));
 
         RenderOtherTabs(style);
 
@@ -233,7 +233,7 @@ public class StylegroundViewTab : Tab
 
         var only = style.OnlyIn;
 
-        ImGui.Text(only is { } ? string.Join(',', only) : "");
+        ImGui.TextUnformatted(only is { } ? string.Join(',', only) : "");
     }
 
     private static string GetName(Backdrop style)

--- a/MappingUtils.csproj
+++ b/MappingUtils.csproj
@@ -7,7 +7,7 @@
         <LangVersion>12.0</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
-        <Optimize>True</Optimize>
+        <!-- <Optimize>True</Optimize> -->
 
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.dll')">..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>

--- a/MappingUtils.csproj
+++ b/MappingUtils.csproj
@@ -9,9 +9,7 @@
         <Nullable>enable</Nullable>
         <Optimize>True</Optimize>
 
-        <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste-core\Celeste.exe')">..\..\..\Celeste-core</CelestePrefix>
-        <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.exe')">..\..</CelestePrefix>
-        <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.exe')">..\..\..</CelestePrefix>
+        <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.dll')">..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
     </PropertyGroup>
 
@@ -21,61 +19,36 @@
         <Reference Private="false" />
     </ItemDefinitionGroup>
 -->
+
     <ItemGroup>
-        <PackageReference Include="CelesteAnalyzer" Version="1.0.3.1" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.1" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="MonoMod.Patcher" Version="25.0.0-prerelease.2" />
+        <PackageReference Include="CelesteAnalyzer" Version="*" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="CelesteMod.Publicizer" Version="*" CelesteAssembly="$(CelestePrefix)\Celeste.dll" />
+        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" Private="false" />
+        <Reference Include="$(CelestePrefix)\FNA.dll" Private="false" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="ICSharpCode.Decompiler" Version="9.0.0.7660-preview2">
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive; runtime</IncludeAssets>
         </PackageReference>
-
-        <PackageReference Include="Mono.Cecil" Version="0.11.5" />
 
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" PrivateAssets="all" ExcludeAssets="runtime" />
         <PackageReference Include="ImGui.NET" Version="1.91.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-
-        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>build</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(CelestePrefix)\Celeste.dll" Publicize="true">
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="$(CelestePrefix)\MonoMod.exe">
-          <Private>false</Private>
-        </Reference>
-        <Reference Include="$(CelestePrefix)\MonoMod.RuntimeDetour.dll">
-          <Private>false</Private>
-        </Reference>
-        <Reference Include="$(CelestePrefix)\MonoMod.Utils.dll">
-          <Private>false</Private>
-        </Reference>
-        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll">
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="$(CelestePrefix)\FNA.dll">
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="ImGuiHelper">
-            <HintPath>lib\ImGuiHelper.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="ImGuiColorTextEditNet">
-            <HintPath>lib\ImGuiColorTextEditNet.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Microsoft.Diagnostics.NETCore.Client">
-            <HintPath>lib\eventTrace\Microsoft.Diagnostics.NETCore.Client.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-            <HintPath>lib\eventTrace\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
+        <Reference Include="lib\ImGuiHelper.dll" Private="false"/>
+        <Reference Include="lib\ImGuiColorTextEditNet.dll" Private="false"/>
+        <Reference Include="lib\eventTrace\Microsoft.Diagnostics.NETCore.Client.dll" Private="false"/>
+        <Reference Include="lib\eventTrace\Microsoft.Diagnostics.Tracing.TraceEvent.dll" Private="false"/>
     </ItemGroup>
 
     <Target Name="CopyFiles" AfterTargets="Build">

--- a/MappingUtils.csproj
+++ b/MappingUtils.csproj
@@ -53,6 +53,7 @@
 
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
+        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
         <Copy SourceFiles="lib\ImGuiColorTextEditNet.dll" DestinationFolder="bin" />
         <Copy SourceFiles="lib\ImGuiColorTextEditNet.LICENSE.txt" DestinationFolder="bin" />
         <Copy SourceFiles="lib\ICSharpCode.Decompiler.dll" DestinationFolder="bin" />


### PR DESCRIPTION
ImGui's Text widgets accept printf-style formatting - see [`imgui/imgui_widgets.cpp:L269-270`](https://github.com/ocornut/imgui/blob/fbcf95193f40fc57a3f0a3e8f59798de06e69bc6/imgui_widgets.cpp#L269-L270).
When Mapping Utils attempts to write a piece of text that contains a percent sign (like `%n`), ImGui crashes Celeste entirely with a `0xC0000409` HRESULT (`STATUS_STACK_BUFFER_OVERFLOW`) as it accesses out-of-bounds memory.

This PR fixes it by changing all affected functions to ones that print the text verbatim. It also does some csproj changes to make it compile along with some miscellaneous edits; feel free to let me know if any of these need adjusting.